### PR TITLE
[FRONTEND] initialize 로직 개선 및 관심사 제출 추가

### DIFF
--- a/frontend/src/api/userSetting/apiClient.ts
+++ b/frontend/src/api/userSetting/apiClient.ts
@@ -1,4 +1,4 @@
-import { useTokenStore } from '../stores/useTokenStore';
+import { useTokenStore } from '../../stores/useTokenStore';
 import axios from 'axios';
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 

--- a/frontend/src/api/userSetting/expertVerify.ts
+++ b/frontend/src/api/userSetting/expertVerify.ts
@@ -1,4 +1,4 @@
-import { useTokenStore } from "../stores/useTokenStore";
+import { useTokenStore } from "../../stores/useTokenStore";
 
 interface ExpertVerifyData {
     certification?: string;

--- a/frontend/src/api/userSetting/initialize.ts
+++ b/frontend/src/api/userSetting/initialize.ts
@@ -1,0 +1,57 @@
+import { useProfileSetupStore } from "../../stores/useProfileSetupStore";
+import { useTokenStore } from "../../stores/useTokenStore";
+import { useAuthStore } from "../../stores/useAuthStore";
+import type { UserData } from "../../types/user";
+
+interface InitializeUserRequest {
+  role: string;
+  interest_ids: number[];
+  custom_interests?: string[];
+}
+
+interface InitializeUserResponse {
+  success: boolean;
+  message: string;
+  data: UserData;
+}
+
+export const initialize = async (): Promise<InitializeUserResponse> => {
+  const { tempRole, tempInterestIds, tempCustomInterests } = useProfileSetupStore.getState();
+  const { accessToken } = useTokenStore.getState();
+
+  if (!accessToken) {
+    throw new Error("인증 토큰이 없습니다. 다시 로그인해주세요.");
+  }
+  if (!tempRole || (tempInterestIds.length === 0 && (!tempCustomInterests || tempCustomInterests.length === 0))) {
+    throw new Error("레벨과 관심사 또는 맞춤 관심사를 하나 이상 선택해주세요.");
+  }
+
+  const requestBody: InitializeUserRequest = {
+    role: tempRole,
+    interest_ids: tempInterestIds,
+    custom_interests: tempCustomInterests && tempCustomInterests.length > 0 ? tempCustomInterests : undefined,
+  };
+
+  const response = await fetch(`${import.meta.env.VITE_API_URL}/users/initialize`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
+  }
+
+  const result: InitializeUserResponse = await response.json();
+
+  if (result.success && result.data) {
+    const { setUser } = useAuthStore.getState();
+    setUser(result.data);
+  }
+
+  return result;
+};

--- a/frontend/src/api/userSetting/initializeUser.ts
+++ b/frontend/src/api/userSetting/initializeUser.ts
@@ -1,6 +1,6 @@
-import type { UserData } from "../types/user";
-import { useTokenStore } from "../stores/useTokenStore";
-import { useAuthStore } from "../stores/useAuthStore";
+import type { UserData } from "../../types/user";
+import { useTokenStore } from "../../stores/useTokenStore";
+import { useAuthStore } from "../../stores/useAuthStore";
 
 interface InitializeUserRequest {
   role: keyof UserRole;
@@ -20,7 +20,7 @@ export const initializeUser = async (userData: InitializeUserRequest): Promise<I
     
     console.log("초기화 API 요청 전 토큰 상태:", {
       hasToken: !!accessToken,
-      tokenPreview: accessToken ? `${accessToken.substring(0, 20)}...` : "없음"
+      tokenPreview: accessToken ? `${accessToken}...` : "없음"
     });
     
     if (!accessToken) {

--- a/frontend/src/api/userSetting/useKakaoLogin.ts
+++ b/frontend/src/api/userSetting/useKakaoLogin.ts
@@ -1,8 +1,8 @@
 // frontend/src/api/useKakaoLogin.ts
 import axios from "axios";
 import { useMutation } from "@tanstack/react-query";
-import { useAuthStore } from "../stores/useAuthStore";
-import { useTokenStore } from "../stores/useTokenStore";
+import { useAuthStore } from "../../stores/useAuthStore";
+import { useTokenStore } from "../../stores/useTokenStore";
 import { useNavigate } from "react-router-dom"; // useNavigate import
 
 export const useKakaoLogin = () => {

--- a/frontend/src/api/userSetting/useLogout.ts
+++ b/frontend/src/api/userSetting/useLogout.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
-import { useAuthStore } from "../stores/useAuthStore";
-import { useTokenStore } from "../stores/useTokenStore";
+import { useAuthStore } from "../../stores/useAuthStore";
+import { useTokenStore } from "../../stores/useTokenStore";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 

--- a/frontend/src/api/userSetting/userService.ts
+++ b/frontend/src/api/userSetting/userService.ts
@@ -1,6 +1,6 @@
 // src/api/userService.ts
-import { useTokenStore } from "../stores/useTokenStore";
-import type { UserData } from "../types/user";
+import { useTokenStore } from "../../stores/useTokenStore";
+import type { UserData } from "../../types/user";
 import apiClient from "./apiClient";
 import { useQuery } from "@tanstack/react-query";
 

--- a/frontend/src/components/common/signIn/signInButton/signInButton.tsx
+++ b/frontend/src/components/common/signIn/signInButton/signInButton.tsx
@@ -1,6 +1,6 @@
 import style from "./signInButton.module.css";
 import kakao from "@/assets/image/kakao.svg";
-import { useKakaoLogin } from "@/api/useKakaoLogin";
+import { useKakaoLogin } from "@/api/userSetting/useKakaoLogin";
 
 export default function SignInButton() {
   const { initiateKakaoLogin } = useKakaoLogin();

--- a/frontend/src/components/layout/settingLayout.tsx
+++ b/frontend/src/components/layout/settingLayout.tsx
@@ -8,7 +8,7 @@ import stepImg from "@/assets/image/step-status.svg";
 import ExpertPopup from "../common/setting/expertPopup/expertPopup";
 import { useNavigate } from "react-router";
 import { useState, useEffect } from "react";
-import { useUpdateProfile } from "../../hooks/useUpdateProfile";
+import { useProfileSetupStore } from "../../stores/useProfileSetupStore";
 
 export default function SettingLayout() {
   const [abled, setAbled] = useState(false);
@@ -18,31 +18,24 @@ export default function SettingLayout() {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
 
   const navigate = useNavigate();
-  const updateProfileMutation = useUpdateProfile();
+  const { setTempRole } = useProfileSetupStore(); // 추가
 
   useEffect(() => {
     setAbled(selectedLevel !== null);
   }, [selectedLevel]);
+
   const handleLevelSelect = (level: "BEGINNER" | "EXPERT" | null) => {
     setSelectedLevel(level);
   };
 
   const handleNext = async () => {
     if (!selectedLevel) return;
-    try {
-      await updateProfileMutation.mutateAsync({
-        role: selectedLevel,
-      });
+    setTempRole(selectedLevel);
 
-      // 성공 시 다음 페이지로 이동
-      if (selectedLevel === "EXPERT") {
-        setIsPopupOpen(true);
-      } else if (selectedLevel == "BEGINNER") {
-        navigate("/second-setting");
-      }
-    } catch (error) {
-      console.error("레벨 저장 실패:", error);
-      alert("레벨 저장에 실패했습니다. 다시 시도해주세요.");
+    if (selectedLevel === "EXPERT") {
+      setIsPopupOpen(true);
+    } else if (selectedLevel === "BEGINNER") {
+      navigate("/second-setting");
     }
   };
 
@@ -75,14 +68,7 @@ export default function SettingLayout() {
           />
         </div>
         <div className={style.btnContainer}>
-          {updateProfileMutation.isPending ? (
-            <div className={style.loadingIndicator}>저장 중...</div>
-          ) : (
-            <NextButton
-              btnAbled={abled && !updateProfileMutation.isPending}
-              onClick={handleNext}
-            />
-          )}
+          <NextButton btnAbled={abled} onClick={handleNext} />
         </div>
       </div>
     </div>

--- a/frontend/src/examples/InitializeUserTest.tsx
+++ b/frontend/src/examples/InitializeUserTest.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+import { initializeUser } from "../api/userSetting/initializeUser";
+
+function InitializeUserTest() {
+  const [role, setRole] = useState<"BEGINNER" | "EXPERT">("BEGINNER");
+  const [interestIds, setInterestIds] = useState<number[]>([]);
+  const [result, setResult] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [customInterests, setCustomInterests] = useState<string[]>([]);
+
+  const handleSubmit = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await initializeUser({
+        role,
+        interest_ids: interestIds,
+        custom_interests: customInterests,
+      });
+      setResult(res);
+    } catch (err: any) {
+      setError(err.message || "에러 발생");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h2>InitializeUser API 테스트</h2>
+      <div>
+        <label>
+          레벨:
+          <select
+            value={role}
+            onChange={(e) => setRole(e.target.value as "BEGINNER" | "EXPERT")}
+          >
+            <option value="BEGINNER">BEGINNER</option>
+            <option value="EXPERT">EXPERT</option>
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>
+          관심사 ID (쉼표로 구분):
+          <input
+            type="text"
+            value={interestIds.join(",")}
+            onChange={(e) =>
+              setInterestIds(
+                e.target.value
+                  .split(",")
+                  .map((s) => Number(s.trim()))
+                  .filter((n) => !isNaN(n))
+              )
+            }
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          맞춤 관심사 (쉼표로 구분):
+          <input
+            type="text"
+            value={customInterests.join(",")}
+            onChange={(e) =>
+              setCustomInterests(e.target.value.split(",").map((s) => s.trim()))
+            }
+          />
+        </label>
+      </div>
+      <button onClick={handleSubmit} disabled={loading}>
+        {loading ? "전송 중..." : "API 테스트"}
+      </button>
+      {error && <div style={{ color: "red" }}>에러: {error}</div>}
+      {result && (
+        <pre style={{ background: "#eee", padding: 10 }}>
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+export default InitializeUserTest;

--- a/frontend/src/hooks/useAutoLogout.ts
+++ b/frontend/src/hooks/useAutoLogout.ts
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef } from 'react';
-import { useLogout } from '../api/useLogout';
+import { useLogout } from '../api/userSetting/useLogout';
 import { useTokenStore } from '../stores/useTokenStore';
-import { refreshAccessToken } from '../api/apiClient';
+import { refreshAccessToken } from '../api/userSetting/apiClient';
 
 interface UseAutoLogoutOptions {
   // 비활성 타임아웃 (기본 30분)

--- a/frontend/src/hooks/useUpdateProfile.ts
+++ b/frontend/src/hooks/useUpdateProfile.ts
@@ -1,7 +1,7 @@
 // src/hooks/useUpdateProfile.ts
 import { useMutation } from '@tanstack/react-query';
 import { useAuthStore } from '../stores/useAuthStore';
-import apiClient from '../api/apiClient';
+import apiClient from '../api/userSetting/apiClient';
 import type UserData from '../types/user';
 import type { UserRoleType } from '../types/user';
 interface UpdateProfileRequest {

--- a/frontend/src/pages/oauth/kakao/RedirectPage.tsx
+++ b/frontend/src/pages/oauth/kakao/RedirectPage.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useRef } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
-import { useKakaoLogin } from "../../../api/useKakaoLogin";
+import { useKakaoLogin } from "../../../api/userSetting/useKakaoLogin";
 import RedirectPageLayout from "../../../components/layout/redirectPageLayout";
 import { useAuthStore } from "../../../stores/useAuthStore";
-import { useUser } from "../../../api/userService";
+import { useUser } from "../../../api/userSetting/userService";
 
 export default function RedirectPage() {
   const [searchParams] = useSearchParams();

--- a/frontend/src/stores/useAuthStore.ts
+++ b/frontend/src/stores/useAuthStore.ts
@@ -53,7 +53,7 @@ export const useAuthStore = create<AuthState>()(
             name: "auth-store",
             partialize: (state) => ({ 
                 user: state.user, 
-                isAuthenticated: state.isAuthenticated 
+                isAuthenticated: state.isAuthenticated
             }),
         }
     )

--- a/frontend/src/stores/useProfileSetupStore.ts
+++ b/frontend/src/stores/useProfileSetupStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+interface ProfileSetupState {
+  tempRole: string | null;
+  tempInterestIds: number[];
+  tempCustomInterests: string[];
+  setTempRole: (role: string) => void;
+  setTempInterestIds: (ids: number[]) => void;
+  setTempCustomInterests: (interests: string[]) => void;
+  clearProfileSetup: () => void;
+}
+
+export const useProfileSetupStore = create<ProfileSetupState>((set) => ({
+  tempRole: null,
+  tempInterestIds: [],
+  tempCustomInterests: [],
+  setTempRole: (role) => set({ tempRole: role }),
+  setTempInterestIds: (ids) => set({ tempInterestIds: ids }),
+  setTempCustomInterests: (interests) => set({ tempCustomInterests: interests }),
+  clearProfileSetup: () => set({ tempRole: null, tempInterestIds: [], tempCustomInterests: [] }),
+}));


### PR DESCRIPTION
## 📝작업 내용

> 기존 역할 제출 시 api 호출 후 관심사 제출때도 api 호출을 하던 로직을 한번에 제출하는 방식으로 변경
> userInitialize.ts에 통합된 제출 로직 제작, useProfileSetupStore.ts에 제출에 필요한 role, interest_ids, custom_interest_ids 상태관리 store 제작, settingLayout 수정